### PR TITLE
Add a 'paths' optional parameter

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,21 @@ encoding
   Encoding to be used to read an OpenAPI spec. If not passed, Sphinx's
   source encoding will be used.
 
+paths
+  A comma separated list of paths to filter the included openapi spec by.
+  For example:
+
+  .. code:: restructuredtext
+
+     .. openapi:: specs/openapi.yml
+        :paths:
+           /persons
+           /evidence
+        :encoding: utf-8
+
+  Would only render the endpoints at ``/persons`` and ``/evidence``,
+  ignoring all others.
+
 
 .. _Sphinx: https://sphinx.pocoo.org/latest
 .. _OpenAPI: https://openapis.org/specification

--- a/docs/specs/openapi.yml
+++ b/docs/specs/openapi.yml
@@ -4,6 +4,18 @@ info:
   version: "1.0.0"
 host: api.batcomputer.com
 paths:
+  /persons:
+    get:
+      summary: List Persons
+      description: |
+        Retrieves a list of all persons on file in the bat computer.
+      responses:
+        200:
+          description: An array of Persons
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Person'
   /evidence:
     get:
       summary: List Evidence
@@ -110,3 +122,13 @@ definitions:
       message:
         type: string
         description: A human readable error message.
+  Person:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: Unique ID for a person
+      name:
+        type: string
+        description: Name of a person

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -118,6 +118,69 @@ class TestOpenApi2HttpDomain(object):
                   error
         ''').lstrip()
 
+    def test_path_option(self):
+        spec = collections.defaultdict(collections.OrderedDict)
+        spec['paths']['/resource_a'] = {
+            'get': {
+                'description': 'resource a',
+                'responses': {
+                    '200': {'description': 'ok'},
+                }
+            }
+        }
+        spec['paths']['/resource_b'] = {
+            'post': {
+                'description': 'resource b',
+                'responses': {
+                    '404': {'description': 'error'},
+                }
+            }
+        }
+
+        options = {
+            'paths': ['/resource_a']
+        }
+        text = '\n'.join(openapi.openapi2httpdomain(spec, **options))
+        assert text == textwrap.dedent('''
+            .. http:get:: /resource_a
+               :synopsis: null
+
+               resource a
+
+               :status 200:
+                  ok
+        ''').lstrip()
+
+    def test_path_invalid(self):
+        spec = collections.defaultdict(collections.OrderedDict)
+        spec['paths']['/resource_a'] = {
+            'get': {
+                'description': 'resource a',
+                'responses': {
+                    '200': {'description': 'ok'},
+                }
+            }
+        }
+        spec['paths']['/resource_b'] = {
+            'post': {
+                'description': 'resource b',
+                'responses': {
+                    '404': {'description': 'error'},
+                }
+            }
+        }
+
+        options = {
+            'paths': ['/resource_a', '/resource_invalid_name']
+        }
+        try:
+            openapi.openapi2httpdomain(spec, **options)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError('Should raise ValueError if a filter ' +
+                                 'path is invalid')
+
 
 class TestResolveRefs(object):
 


### PR DESCRIPTION
## Overview

We ran into some additional limitations that were troublesome when attempting to use local refs as provided by sphinxcontrib-openapi@0.2.1. As a result, we needed finer grained control over which `paths` of a given OpenAPI spec we render at a particular location in our docs. 

This PR adds an additional `paths` option to the `.. openapi::` directive that allows the user to specify which paths they want to render using the directive. If not provided, the directive continues to render all paths found in the file.

### Sample Usage

Sample usage is demonstrated by the changeset in `docs/index.rst`:
![sphinx-contribopenapi-docs-paths](https://cloud.githubusercontent.com/assets/1818302/21865041/5b9245ea-d812-11e6-8969-7bea57492a97.png)

## Testing

Tests should continue to pass. Run tests by ensuring [tox](https://pypi.python.org/pypi/tox) is installed (via pip or in a virtualenv or other), then simply run `tox` with no arguments in the project dir after checking this branch out. 

You may see an error for any versions of python that aren't installed on your system. This should be fine as long as tests pass on at least one version of python 2 and python 3.